### PR TITLE
chore(readme): remover links a Redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ No dejes de explorar la documentación oficial de cada herramienta:
 
 * [React - docs oficiales](https://es.reactjs.org/)
 * [React - tutorial](https://egghead.io/courses/the-beginner-s-guide-to-react)
-* [Redux - tutorial](https://egghead.io/courses/getting-started-with-redux)
 * [create-react-app](https://github.com/facebook/create-react-app)
 * [React js en español - tutorial básico, primeros pasos y ejemplos - frontendlabs.io](https://frontendlabs.io/3158--react-js-espanol-tutorial-basico-primeros-pasos-ejemplos)
 
@@ -124,7 +123,6 @@ No dejes de explorar la documentación oficial de cada herramienta:
 * [Angular CLI](https://cli.angular.io/)
 * [Angular - tutorial](https://www.youtube.com/watch?v=0eWrpsCLMJQ&list=PLC3y8-rFHvwhBRAgFinJR8KHIrCdTkZcZ)
 * [Angular - crud](https://www.youtube.com/watch?v=6wVolJfXn1c)
-* [Angular - redux](https://www.youtube.com/playlist?list=PLCKuOXG0bPi3FtoplJe0JOpiV6OyK30wd)
 
 ### Vue
 
@@ -133,10 +131,6 @@ No dejes de explorar la documentación oficial de cada herramienta:
 * [Vue- adicional](https://scotch.io/search?q=vue)
 * [Vue- school](https://vueschool.io/)
 
-Independientemente de si eliges React, Vue o Angular, todos estas herramientes
-se usan muchas veces en conjunción con Redux como manejador de _estado_.
-
-* [Redux - docs oficiales](https://redux.js.org/)
 
 ## 9. Checklist
 


### PR DESCRIPTION
Creo que este proyecto no necesita de Redux para su implementacion, ademas el aprendizaje de Redux no es trivial, asi que hacemos un favor a las estudiantes, y coaches, removiendo complejidad. Como alternativa a Redux podemos usar `useState` o `context` incluidos por React, en el caso de angular no tengo idea pero creo que puede solucionarse de forma similar